### PR TITLE
Use lowercased username in login handshake

### DIFF
--- a/audioscrobbler.cpp
+++ b/audioscrobbler.cpp
@@ -290,9 +290,9 @@ CAudioScrobbler::Handshake()
 	std::string authtoken(md5sum((char*)"%s%s", username.c_str(), Config->getLPassword().c_str()));
 
 	std::ostringstream query, sig;
-	query << "method=auth.getMobileSession&username=" << Config->getLUsername() << "&authToken=" << authtoken << "&api_key=" << APIKEY;
+	query << "method=auth.getMobileSession&username=" << username << "&authToken=" << authtoken << "&api_key=" << APIKEY;
 
-	sig << "api_key" << APIKEY << "authToken" << authtoken << "methodauth.getMobileSessionusername" << Config->getLUsername() << SECRET;
+	sig << "api_key" << APIKEY << "authToken" << authtoken << "methodauth.getMobileSessionusername" << username << SECRET;
 	std::string sighash(md5sum((char*)"%s", sig.str().c_str()));
 
 	query << "&api_sig=" << sighash;


### PR DESCRIPTION
Lowercased username was already computed to create the ```authToken```'s md5 hash. So this is a very small change. As I said in #22, this does not look like a mpdas issue, but solves that undocumented change in the last.fm API.