### PR TITLE
Added UPnP monitoring support, made configurable using autotools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,18 @@
 *.exe
 *.out
 *.app
+
+# Autoconf stuff
+.deps
+Makefile
+Makefile.in
+aclocal.m4
+autom4te.cache
+compile
+config.log
+config.status
+configure
+depcomp
+install-sh
+missing
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,18 @@
+
+AM_CPPFLAGS = -DCONFDIR="\"$(sysconfdir)\"" -DVERSION="\"$(VERSION)\""
+AM_CXXFLAGS = -std=c++11
+
+bin_PROGRAMS = mpdas
+
+mpdas_SOURCES= \
+    main.cpp md5.cpp utils.cpp mpd.cpp audioscrobbler.cpp cache.cpp \
+    config.cpp
+
+if DOUPNP
+   mpdas_SOURCES += upnpav.cpp
+endif
+
+mpdas_LDADD = $(MPDAS_LIBS)
+
+
+dist_man1_MANS = mpdas.1

--- a/README
+++ b/README
@@ -52,6 +52,19 @@ Features:
 - User switching
 - "Love" tracks on Last.fm
     (e.g. with 'mpc sendmessage mpdas love')
+- Optional UPnP support (see next)
+================================================
+
+If mpdas is configured with --enable-upnp, it supports monitoring an
+UPnP renderer (as an alternative to monitoring mpd).
+
+The build will need libupnpp:
+http://www.lesbonscomptes.com/upmpdcli/downloads.
+
+The switch to UPnP use is triggered by the presence of the
+upnpname variable inside the configuration file:
+
+upnpname = upnp-friendly-name-or-uuid
 
 ================================================
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,3 @@
+aclocal
+automake --force-missing --add-missing
+autoconf

--- a/config.cpp
+++ b/config.cpp
@@ -31,6 +31,8 @@ CConfig::ParseLine(std::string line)
 			_mport = atoi(tokens[1].c_str());
 		else if(tokens[0] == "runas")
 			_runninguser = tokens[1];
+		else if(tokens[0] == "upnpname")
+			_upnpname = tokens[1];
 		else if(tokens[0] == "debug") {
 			if(tokens[1] == "1" || tokens[1] == "true")
 				_debug = true;

--- a/config.h
+++ b/config.h
@@ -11,6 +11,7 @@ class CConfig
 		std::string getMHost() { return _mhost; }
 		std::string getMPassword() { return _mpassword; }
 		std::string getRUser() { return _runninguser; }
+		std::string getUPnPName() { return _upnpname; }
 		bool getDebug() { return (_debug == true); }
 		int getMPort() { return _mport; }
 
@@ -25,6 +26,7 @@ class CConfig
 		std::string _lusername, _lpassword;
 		std::string _mhost, _mpassword;
 		std::string _runninguser;
+		std::string _upnpname;
 		int _mport;
 		bool _debug;
 };

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,46 @@
+AC_INIT([mpdas], [0.4.1], [henrik@affekt.org],
+             [mpdas], [http://www.50hz.ws])
+AC_PREREQ([2.53])
+AC_CONFIG_SRCDIR([mpdas.h])
+
+AM_INIT_AUTOMAKE([1.10 no-define subdir-objects foreign])
+
+AC_PROG_CXX
+
+# ! Not sure that this is needed for upmpdcli and not only libupnpp
+# libupnp is configured with large file support, and we need to do the same,
+# else a difference in off_t size impacts struct File_Info and prevents the
+# vdir to work. This does make a difference, for exemple, for Raspbian
+# on the Raspberry PI. Use the same directives as libupnp's configure.ac
+AC_TYPE_SIZE_T
+AC_TYPE_OFF_T
+AC_DEFINE([_LARGE_FILE_SOURCE], [], [Large files support])
+AC_DEFINE([_FILE_OFFSET_BITS], [64], [File Offset size])
+
+#### Libraries
+
+# Support monitoring an UPnP renderer
+AC_ARG_ENABLE(upnp,
+    AC_HELP_STRING([--enable-upnp],
+   [Enable upnp monitoring (needs libupnpp).]),
+        upnpEnabled=$enableval, upnpEnabled=no)
+AM_CONDITIONAL(DOUPNP, [test X$upnpEnabled = Xyes])
+if test X$upnpEnabled = Xyes ; then
+   AC_CHECK_LIB([upnpp], [getsyshwaddr], [], [AC_MSG_ERROR([libupnpp])])
+   AC_DEFINE(WITH_UPNP, 1, [Support UPnP monitoring])
+fi
+
+AC_CHECK_LIB([curl], [curl_easy_init], [],AC_MSG_ERROR([libcurl not found]))
+AC_CHECK_LIB([mpdclient], [mpd_connection_new], [],
+                          AC_MSG_ERROR([libmpdclient not found]))
+
+
+MPDAS_LIBS="$LIBS"
+echo "MPDAS_LIBS=$LIBS"
+
+LIBS=""
+
+AC_SUBST(MPDAS_LIBS)
+
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT

--- a/upnpav.cpp
+++ b/upnpav.cpp
@@ -1,0 +1,212 @@
+// UPnP support for mpdas
+
+#include "mpdas.h"
+
+#include "upnpav.h"
+
+#include "libupnpp/upnpplib.hxx"
+#include "libupnpp/control/discovery.hxx"
+#include "libupnpp/control/mediarenderer.hxx"
+#include "libupnpp/control/renderingcontrol.hxx"
+
+using namespace std;
+using namespace UPnPClient;
+using namespace UPnPP;
+
+CUPNP* UPNP = 0;
+
+class CUPNP::Internal {
+public:
+
+	MRDH renderer;
+	AVTH avt;
+	OHPRH ohpr;
+	OHPLH ohpl;
+	OHTMH ohtm;
+	Song song;
+	bool gotsong;
+	time_t starttime;
+	bool connected;
+	bool cached;
+	string cururi;
+	int songpos;
+};
+
+void
+CUPNP::SetSong(const Song *song)
+{
+	m->cached = false;
+	if(song && !song->getArtist().empty() && !song->getTitle().empty()) {
+		m->song = *song;
+		m->gotsong = true;
+		//iprintf("New song: %s - %s", m->song.getArtist().c_str(),
+		// m->song.getTitle().c_str());
+		AudioScrobbler->SendNowPlaying(*song);
+	} else {
+		m->gotsong = false;
+	}
+	m->starttime = time(NULL);
+}
+
+void
+CUPNP::CheckSubmit(int playtime)
+{
+	if(!m->gotsong || m->cached || m->song.getArtist().empty() ||
+	   m->song.getTitle().empty() || m->song.getDuration() < 5)
+		return;
+
+	//iprintf("CheckSubmit: playtime %d, songduration %d", playtime,
+	//m->song.getDuration());
+	if(playtime >= 240 ||
+	   playtime >= m->song.getDuration()/2) {
+		Cache->AddToCache(m->song, m->starttime);
+		m->cached = true;
+	}
+}
+
+CUPNP::CUPNP()
+{
+	m = new Internal;
+	m->gotsong = false;
+	m->connected = false;
+	m->cached = false;
+	m->songpos = -1;
+
+        Logger::getTheLog("")->setLogLevel(Logger::LLERR);
+	if(Connect())
+		iprintf("%s", "Connected to UPNP.");
+	else
+		eprintf("%s", "Could not connect to UPNP.");
+}
+
+CUPNP::~CUPNP()
+{
+	delete m;
+}
+
+bool
+CUPNP::Connect()
+{
+	m->connected = false;
+	UPnPDeviceDirectory *superdir = UPnPDeviceDirectory::getTheDir();
+	if (superdir == 0) {
+		return false;
+	}
+
+	UPnPDeviceDesc ddesc;
+	if (superdir->getDevByFName(Config->getUPnPName(), ddesc)) {
+		m->renderer = MRDH(new MediaRenderer(ddesc));
+	} else if (superdir->getDevByUDN(Config->getUPnPName(), ddesc)) {
+		m->renderer = MRDH(new MediaRenderer(ddesc));
+	}
+
+	m->avt = m->renderer->avt();
+	if (!m->avt) {
+		// Let's try with openhome
+		m->ohpr = m->renderer->ohpr();
+		m->ohpl = m->renderer->ohpl();
+		m->ohtm = m->renderer->ohtm();
+		if (!m->ohpr || !m->ohpl || !m->ohtm)
+			return false;
+	}
+	return m->connected = true;
+}
+
+bool
+CUPNP::isConnected()
+{
+	return m->connected;
+}
+
+void
+CUPNP::Update()
+{
+	if(!m->connected) {
+		iprintf("Reconnecting in 10 seconds.");
+		sleep(10);
+		if(Connect())
+			iprintf("%s", "Reconnected!");
+		else {
+			eprintf("%s", "Could not reconnect.");
+			return;
+		}
+	}
+
+	UPnPDirObject trackmeta;
+	int reltime;
+	string trackuri;
+	int trackduration;
+	if (m->avt) {
+		UPnPClient::AVTransport::PositionInfo info;
+		if (m->avt->getPositionInfo(info) != 0) {
+			m->connected = false;
+			return;
+		}
+		trackmeta = info.trackmeta;
+		reltime = info.reltime;
+		trackuri = info.trackuri;
+		trackduration = info.trackduration;
+	} else if (m->ohpr && m->ohpl && m->ohtm) {
+		vector<OHProduct::Source> sources;
+		int index;
+		if (m->ohpr->getSources(sources) != 0 ||
+			    m->ohpr->sourceIndex(&index) != 0) {
+			eprintf("OpenHome: can't get source info !");
+			return;
+		}
+		// 
+		if (index < 0 || index > int(sources.size()) ||
+		    sources[index].type.compare("Playlist")) {
+		    // Can't use source
+		    return;
+		}
+
+		int id;
+		if (m->ohpl->id(&id) != 0 || id == 0) {
+			return;
+		}
+		if (m->ohpl->read(id, &trackuri, &trackmeta) != 0) {
+			return;
+		}
+		UPnPClient::OHTime::Time tm;
+		if (m->ohtm->time(tm) != 0) {
+			return;
+		}
+		trackduration = tm.duration;
+		reltime = tm.seconds;
+	} else {
+		// ??
+		m->connected = false;
+		return;
+	}
+
+	// new song? Pb: the Uri changes slightly before the metadata, so
+	// that if we use an uri change to update the meta, we get the one
+	// from the previous song. So have to use the meta itself no big deal
+	// In addition, duration also changes before the title ! Best to wait
+	// a few secs play time before we do anything
+	string artist(trackmeta.getprop("upnp:artist"));
+	string album(trackmeta.getprop("upnp:album"));
+	//iprintf("Current info: duration %d reltime %d, title %s",
+	//	   trackduration, reltime, trackmeta.m_title.c_str());
+	if(reltime >= 3 &&
+	   (!m->gotsong || 
+		m->song.getTitle().compare(trackmeta.m_title) ||
+		m->song.getAlbum().compare(album) ||
+		m->song.getArtist().compare(artist))) {
+
+		m->cururi = trackuri;
+		m->songpos = reltime;
+		Song s(artist,
+			   trackmeta.m_title,
+			   album,
+			   trackduration);
+		SetSong(&s);
+	}
+
+	// song playing
+	if(m->songpos != reltime) {
+		m->songpos = reltime;
+		CheckSubmit(reltime);
+	}
+}

--- a/upnpav.h
+++ b/upnpav.h
@@ -1,0 +1,27 @@
+#ifndef _UPNPAV_H
+#define _UPNPAV_H
+
+#include "mpd.h" // For Song
+
+class CUPNP
+{
+public:
+	CUPNP();
+	~CUPNP();
+
+	void Update();
+	bool isConnected();
+
+private:
+	class Internal;
+	Internal *m;
+	void GotNewSong(struct mpd_song *song);
+	void SetSong(const Song *song);
+	bool Connect();
+	void CheckSubmit(int curplaytime);
+	Song GetSong();
+};
+
+extern CUPNP* UPNP;
+
+#endif


### PR DESCRIPTION
Hi,

I added simple UPnP Renderer monitoring module, based on libupnpp: http://www.lesbonscomptes.com/upmpdcli/
https://github.com/medoc92/libupnpp

I made it optional using autotools.

The upnp part is only used (and the library made necessary), if --enable-upnp is given to configure.

jf
