### PR TITLE
Designating a folder in which composer tags should be submitted instead of artist tags

### DIFF
--- a/README
+++ b/README
@@ -37,16 +37,16 @@ from now on.
 
 Configuration options:
 
-username:		Last.FM username
-password:		Last.FM password (plain-text)
-host:			MPD Host
-mpdpassword:		MPD Password
-port:			MPD Port
-composerfolder:	Folder holding files that must
+username:       Last.FM username
+password:       Last.FM password (plain-text)
+host:           MPD Host
+mpdpassword:    MPD Password
+port:           MPD Port
+composerfolder: Folder holding files that must
                 submit composer tags instead of
                 artist tags
-runas:			Change the user mpdas runs as
-debug:			Print debug information
+runas:          Change the user mpdas runs as
+debug:          Print debug information
 service:        Will scrobble to Libre.fm if set
                 to "librefm"
 

--- a/README
+++ b/README
@@ -1,10 +1,10 @@
 ================================================
-                     _           
- _ __ ___  _ __   __| | __ _ ___ 
+                     _
+ _ __ ___  _ __   __| | __ _ ___
 | '_ ` _ \| '_ \ / _` |/ _` / __|
 | | | | | | |_) | (_| | (_| \__ \
 |_| |_| |_| .__/ \__,_|\__,_|___/
-          |_| 
+          |_|
 ================================================
 
 mpdas is a MPD AudioScrobbler client
@@ -42,6 +42,9 @@ password:		Last.FM password (plain-text)
 host:			MPD Host
 mpdpassword:		MPD Password
 port:			MPD Port
+composerfolder:	Folder holding files that must
+                submit composer tags instead of
+                artist tags
 runas:			Change the user mpdas runs as
 debug:			Print debug information
 service:        Will scrobble to Libre.fm if set

--- a/config.cpp
+++ b/config.cpp
@@ -30,6 +30,8 @@ void CConfig::ParseLine(std::string line)
 			_service = LibreFm;
 		else if(tokens[0] == "port")
 			_mport = atoi(tokens[1].c_str());
+		else if(tokens[0] == "composerfolder")
+			_composerfolder = tokens[1];
 		else if(tokens[0] == "runas")
 			_runninguser = tokens[1];
 		else if(tokens[0] == "debug") {
@@ -65,6 +67,7 @@ CConfig::CConfig(char* cfg)
 	_service = LastFm;
 	_mport = 6600;
 	_debug = false;
+    _composerfolder = "";
 
 	std::string path = "";
 

--- a/config.h
+++ b/config.h
@@ -16,11 +16,12 @@ class CConfig
 		std::string getMHost() { return _mhost; }
 		std::string getMPassword() { return _mpassword; }
 		std::string getRUser() { return _runninguser; }
+		std::string getMComposerFolder() { return _composerfolder; }
 		ScrobblingService getService() { return _service; }
 		bool getDebug() { return (_debug == true); }
 		int getMPort() { return _mport; }
 
-		bool gotNecessaryData() { 
+		bool gotNecessaryData() {
 			if(!_lusername.size() || !_lpassword.size())
 				return false;
 			return true;
@@ -31,6 +32,7 @@ class CConfig
 		std::string _lusername, _lpassword;
 		std::string _mhost, _mpassword;
 		std::string _runninguser;
+		std::string _composerfolder;
 		ScrobblingService _service;
 		int _mport;
 		bool _debug;

--- a/mpd.cpp
+++ b/mpd.cpp
@@ -145,9 +145,20 @@ void CMPD::Update()
 Song::Song(struct mpd_song *song)
 {
     const char* temp;
+    const char* composer = mpd_song_get_tag(song, MPD_TAG_COMPOSER, 0);
+    std::string _filename = mpd_song_get_uri(song);
 
-    temp = mpd_song_get_tag(song, MPD_TAG_ARTIST, 0);
-    artist = temp ? temp : "";
+    if (!Config->getMComposerFolder().empty()) {
+        if (composer && _filename.find(Config->getMComposerFolder()) != std::string::npos) {
+            artist = composer;
+        } else {
+            temp = mpd_song_get_tag(song, MPD_TAG_ARTIST, 0);
+            artist = temp ? temp : "";
+        }
+    } else {
+        temp = mpd_song_get_tag(song, MPD_TAG_ARTIST, 0);
+        artist = temp ? temp : "";
+    }
 
     temp = mpd_song_get_tag(song, MPD_TAG_TITLE, 0);
     title = temp ? temp : "";

--- a/mpdasrc.example
+++ b/mpdasrc.example
@@ -2,3 +2,4 @@ username = fhen
 password = password
 runas = mpd
 debug = 1
+composerfolder = classical-music/


### PR DESCRIPTION
Not sure if this is useful for everyone, but: for classical music, the 
composer field is what Last.fm will want to receive. 

If classical music files have *correct* tags (meaning a composer as a
composer, and a performer as an artist), setting the config option

    composerfolder = "path/holding/classical-music"

will submit composer instead of artist.

E.g. Alfred Brendel playing a Beethoven sonata:

    composer: Ludwig van Beethoven
    artist: Alfred Brendel
    title: Sonata

will submit "Ludwig van Beethoven - Sonata" to Last.fm, if the file in
question is in the folder designated as `composerfolder`.