### PR TITLE
Add support for environment variables `MPD_HOST` and `MPD_PORT`.

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -48,11 +48,21 @@ ScrobblingService CConfig::getService()
     return Get("service") == "librefm" ? LibreFm : LastFm;
 }
 
+
 CConfig::CConfig(char* cfg)
 {
+    std::string host = "localhost";
+	std::string port = "6600";
+
     /* Set optional settings to default */
-    Set("host", "localhost");
-    Set("port", "6600");
+    if(const char* env_host = std::getenv("MPD_HOST"))
+    	host = env_host;
+
+	if (const char* env_port = std::getenv("MPD_PORT") )
+		port = env_port;
+
+    Set("host", host);
+    Set("port", port);
     Set("debug", "false");
     Set("service", "lastfm");
 

--- a/config.h
+++ b/config.h
@@ -1,7 +1,8 @@
 #ifndef _CONFIG_H
 #define _CONFIG_H
 
-enum ScrobblingService {
+enum ScrobblingService
+{
 	LastFm,
 	LibreFm
 };
@@ -9,7 +10,7 @@ enum ScrobblingService {
 class CConfig
 {
 public:
-	CConfig(char* cfg);
+	CConfig(char *cfg);
 
 	ScrobblingService getService();
 
@@ -18,18 +19,20 @@ public:
 	int GetInt(std::string name);
 	void Set(std::string name, std::string value) { _configuration[name] = value; };
 
-	bool gotNecessaryData() {
-		if(!Get("username").size() || !Get("password").size())
+	bool gotNecessaryData()
+	{
+		if (!Get("username").size() || !Get("password").size())
 			return false;
 		return true;
 	}
 
 	void LoadConfig(std::string path);
+
 private:
 	void ParseLine(std::string line);
 	std::map<std::string, std::string> _configuration;
 };
 
-extern CConfig* Config;
+extern CConfig *Config;
 
 #endif


### PR DESCRIPTION
This PR adds support for the commonly used environment variables like `MPD_HOST` and `MPD_PORT` as discussed in #60 .