### PR TITLE
Skip writing the cache file if there are no entries

### DIFF
--- a/cache.cpp
+++ b/cache.cpp
@@ -4,14 +4,14 @@ CCache* Cache = 0;
 
 void CCache::SaveCache()
 {
+	if(!_entries.size()) {
+		return;
+	}
+
 	std::string path = getenv("HOME");
 	path.append("/.mpdascache");
 	remove(path.c_str());
 	std::ofstream ofs(path.c_str());
-	if(!_entries.size()) {
-		remove(path.c_str());
-		return;
-	}
 
 	for(unsigned int i = 0; i < _entries.size(); i++) {
 		CacheEntry* entry = _entries[i];


### PR DESCRIPTION
Currently `SaveCache` creates and deletes the cache file twice per second even if there are no entries. This change should significantly reduce the number of filesystem operations issued.